### PR TITLE
Add dependencyMap option

### DIFF
--- a/lib/steal_amd.js
+++ b/lib/steal_amd.js
@@ -41,9 +41,9 @@ var normalize = function(name, loader){
 	}
 };
 
-module.exports = function(load){
+module.exports = function(load, options){
 	
-	var moduleNameToVariables = {};
+	var dependencyMap = options && options.dependencyMap;
 	
 	var output = esprima.parse(load.source.toString());
 	
@@ -57,12 +57,15 @@ module.exports = function(load){
 				})  ) {
 			var args = obj.arguments,
 				arg,
+				val,
 				moduleNames = [];
 			var i = 0;
 			while( i < args.length) {
 				arg = args[i];
 				if(arg.type == "Literal") {
-					arg.value = normalize(arg.value);
+					val = normalize(arg.value);
+					arg.value = dependencyMap ?
+						(dependencyMap[val] ? dependencyMap[val] : val) : val;
 					arg.raw = '"'+arg.value+'"';
 					moduleNames.push(arg);
 					args.splice(i, 1);

--- a/main.js
+++ b/main.js
@@ -53,7 +53,7 @@ function moduleType(source) {
 var transpile = {
 	transpilers: transpilers,
 	// transpile.to("amd",load)
-	to: function(load, type){
+	to: function(load, type, options){
 		var format = load.metadata.format || moduleType(load.source);
 		var path = this.able(format, type);
 		
@@ -71,7 +71,7 @@ var transpile = {
 		
 		for(var i =0; i < path.length - 1; i++) {
 			var transpiler = transpilers[path[i]+"_"+path[i+1]] || toSelf;	
-			copy.source = transpiler(copy);
+			copy.source = transpiler(copy, options);
 		}
 		return copy.source;
 	},

--- a/test/test.js
+++ b/test/test.js
@@ -8,19 +8,23 @@ var es62cjs = 		require("../lib/es6_cjs"),
 	assert = require("assert"),
 	transpile = require("../main");
 
-var convert = function(moduleName, converter, result, done){
+var convert = function(moduleName, converter, result, options, done){
+	if(typeof options === "function") {
+		done = options;
+		options = {};
+	}
+
 	fs.readFile(__dirname+"/tests/"+moduleName+".js", function(err, data){
 		if(err) {
 			assert.fail(err, null, "reading "+__dirname+"/tests/"+file+" failed");
 		}
-		var res = converter({source: ""+data, address: __dirname+"/tests/"+moduleName+".js", name: moduleName});
+		var res = converter({source: ""+data, address: __dirname+"/tests/"+moduleName+".js", name: moduleName}, options);
 		assert.ok(res, "got back a value");
 		
 		fs.readFile(__dirname+"/tests/expected/"+result, function(err, resultData){
 			if(err) {
 				assert.fail(err, null, "reading "+__dirname+"/tests/expected/"+result+" failed");
 			}
-			//console.log(res)
 			assert.equal(""+res,""+resultData,"expected equals result");
 			done()
 		});
@@ -73,11 +77,19 @@ describe('amd - cjs', function(){
 
 describe('steal - amd', function(){
     it('should work', function(done){
-		convert("steal",steal2amd,"steal_amd.js", done)
+			convert("steal",steal2amd,"steal_amd.js", done)
     });
     it('should leave nested steals alone', function(done){
 		convert("nested_steal",steal2amd,"nested_steal_amd.js", done)
     });
+		it('should work with a dependencyMap', function(done){
+			var options = {
+				dependencyMap: {
+					'./baz': 'baz'
+				}
+			};
+			convert("steal_deps",steal2amd,"steal_amd_dep.js", options, done);
+		});
 });
 
 describe('global - amd', function(){

--- a/test/tests/expected/steal_amd_dep.js
+++ b/test/tests/expected/steal_amd_dep.js
@@ -1,0 +1,11 @@
+define('steal_deps', [
+    'foo/foo',
+    'bar/bar',
+    'baz'
+], function (foo, bar, baz) {
+    return {
+        foo: foo,
+        bar: bar,
+        baz: baz
+    };
+});

--- a/test/tests/steal_deps.js
+++ b/test/tests/steal_deps.js
@@ -1,0 +1,9 @@
+steal("foo", "bar", "./baz.js", function(foo, bar, baz){
+	
+	return {
+		foo: foo,
+		bar: bar,
+    baz: baz
+	};
+	
+});


### PR DESCRIPTION
This adds the dependencyMap option as a way to allow fully normalized modules to be correctly transpiled. This is for module names that require a loader to normalize. Will be used by steal-tools pluginify.
