### PR TITLE
Makes cjs_amd work with relative path deps

### DIFF
--- a/lib/cjs_amd.js
+++ b/lib/cjs_amd.js
@@ -1,5 +1,41 @@
-module.exports = function(load){
-	return "define('"+load.name+"', function(require, exports, module) {"
-		+load.source+
-		"});";
+var esprima = require('esprima'),
+	traverse = require('./traverse'),
+	escodegen = require('escodegen'),
+	comparify = require('comparify'),
+	optionsNormalize = require('./options_normalize');
+
+module.exports = function(load, options){
+	var source = load.source;
+
+	// If we need to normalize then we must use esprima.
+	if(options.normalizeMap || options.normalize) {
+		var output = esprima.parse(source.toString());
+
+		traverse(output, function(obj){
+			if(comparify(obj, {
+				"type": "CallExpression",
+				"callee": {
+					"type": "Identifier",
+					"name": "require"
+				}
+			})) {
+				var arg = obj.arguments[0];
+				if(arg.type === "Literal") {
+					var val = arg.value;
+					arg.value = optionsNormalize(options, val, load.name, load.address);
+					arg.raw = '"'+arg.value+'"';
+				}
+
+				return false;
+			}
+		});
+
+		source = escodegen.generate(output);
+	}
+
+
+	return "define('"+load.name+"', function(require, exports, module) {\n"
+		+source+
+		"\n});";
+
 };

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,7 @@ var es62cjs = 		require("../lib/es6_cjs"),
 	steal2amd =		require("../lib/steal_amd"),
 	global2amd =	require("../lib/global_amd"),
 	amd2amd = 		require("../lib/amd_amd"),
+	cjs2amd =			require("../lib/cjs_amd"),
 	fs = require("fs"),
 	assert = require("assert"),
 	transpile = require("../main");
@@ -171,3 +172,14 @@ describe('es6 - amd', function(){
 	});
 });
 
+describe('cjs - amd', function(){
+	it("should work with relative dependencies", function(done){
+		var options = {
+			normalizeMap: {
+				'./b': 'b'
+			}
+		};
+
+		convert("cjs_deps", cjs2amd, "cjs_deps.js", options, done);
+	});
+});

--- a/test/tests/cjs_deps.js
+++ b/test/tests/cjs_deps.js
@@ -1,0 +1,6 @@
+var a = require('a'), 
+	b = require('./b');
+	
+exports.action = function () {
+	
+};

--- a/test/tests/expected/cjs_deps.js
+++ b/test/tests/expected/cjs_deps.js
@@ -1,0 +1,5 @@
+define('cjs_deps', function(require, exports, module) {
+var a = require('a'), b = require('b');
+exports.action = function () {
+};
+});


### PR DESCRIPTION
This makes the cjs_amd path work with relative path dependencies. In order to do this we needed to add esprima parsing so that we could replace `require` calls with the dependencyMapped value.

``` js
require('./a');
```

becomes

``` js
require('a');
```
