### PR TITLE
Pass es6 options to compiler

### DIFF
--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -1,4 +1,5 @@
 var babel = require("babel-core");
+var extend = require("lodash/object/extend");
 
 var mapFormat = {
 	'commonjs': 'common',
@@ -6,9 +7,10 @@ var mapFormat = {
 };
 
 module.exports = function(source, options){
-	var result = babel.transform(source, {
+	var opts = extend({}, {
 		modules: mapFormat[options.modules]
-	});
+	}, options.babelOptions);
+	var result = babel.transform(source, opts);
 	return {
 		js: result.code
 	};

--- a/lib/clean_traceur_compile.js
+++ b/lib/clean_traceur_compile.js
@@ -7,6 +7,7 @@ var traceurPath = require.resolve("traceur");
 var search = "/node_modules/traceur/";
 var index = traceurPath.indexOf(search);
 var path = traceurPath.substr(0,index+search.length );
+var extend = require("lodash/object/extend");
 
 for(var name in require.cache) {
 	if( name.indexOf(path) === 0 ) {
@@ -33,15 +34,20 @@ globalNames.forEach(function(name){
 	global[name] = oldGlobals[name];
 });
 
-module.exports = function(){
+module.exports = function(source, options){
 	var saved = {};
 	
 	globalNames.forEach(function(name){
 		saved[name] = global[name];
 		global[name] = globals[name];
 	});
+
+	var opts = extend({}, {
+		filename: options.filename,
+		modules: options.modules
+	}, options.traceurOptions);
 	
-	var result = traceur.compile.apply(traceur, arguments);
+	var result = traceur.compile(source, opts);
 	
 	globalNames.forEach(function(name){
 		global[name] = saved[name];

--- a/lib/es6_amd.js
+++ b/lib/es6_amd.js
@@ -1,12 +1,14 @@
 var amd_amd = require('./amd_amd');
 var getCompile = require('./es6_compiler');
+var extend = require("lodash/object/extend");
 
 module.exports = function(load, options){
 	var compile = getCompile(options);
-
-	load.source = compile(load.source.toString(), {
+	var opts = extend({}, options, {
 		filename: load.address,
 		modules: 'amd'
-	}).js;
+	});
+
+	load.source = compile(load.source.toString(), opts).js;
 	return amd_amd(load, options);
 };

--- a/lib/es6_cjs.js
+++ b/lib/es6_cjs.js
@@ -1,5 +1,6 @@
 var normalizeCJS = require('./normalize_cjs');
 var getCompile = require('./es6_compiler');
+var extend = require("lodash/object/extend");
 
 module.exports = function(load, options){
 	var compile = getCompile(options);
@@ -9,10 +10,11 @@ module.exports = function(load, options){
 		copy[prop] = load[prop];
 	}
 	
-	var result = compile(load.source.toString(), {
+	var opts = extend({}, options, {
 		filename: load.address,
 		modules: 'commonjs'
-	}).js;
+	});
+	var result = compile(load.source.toString(), opts).js;
 	if(options && (options.normalizeMap || options.normalize)) {
 		copy.source = result;
 		return normalizeCJS(copy, options);

--- a/package.json
+++ b/package.json
@@ -8,13 +8,14 @@
     "web" : "http://bitovi.com/"
   },
   "dependencies": {
-    "babel-core": "~4.1.1",
+    "babel-core": "~4.7.12",
     "comparify": "0.1.0",
     "escodegen": "1.3.2",
     "esprima": "1.1.1",
     "estraverse": "1.5.0",
     "js-module-formats": "~0.1.2",
     "js-string-escape": "1.0.0",
+    "lodash": "^3.3.1",
     "traceur": "0.0.58"
   },
   "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -211,6 +211,15 @@ describe('es6 - amd', function(){
 			transpiler: "babel"
 		}, done);
 	});
+
+	it("should pass in babel options", function(done){
+		doTranspile("es6", "es6", "es6_amd_babel_options.js", "amd", {
+			transpiler: "babel",
+			babelOptions: {
+				loose: "es6.modules"
+			}
+		}, done);
+	});
 });
 
 describe('cjs - amd', function(){

--- a/test/tests/expected/es6_amd_babel_options.js
+++ b/test/tests/expected/es6_amd_babel_options.js
@@ -6,7 +6,7 @@ define([
     var _interopRequire = function (obj) {
         return obj && obj.__esModule ? obj['default'] : obj;
     };
-    Object.defineProperty(exports, '__esModule', { value: true });
+    exports.__esModule = true;
     var amdMod = _interopRequire(_basicsAmdmodule);
     exports['default'] = {
         amdModule: amdMod,

--- a/test/tests/expected/es6_cjs_babel.js
+++ b/test/tests/expected/es6_cjs_babel.js
@@ -2,13 +2,15 @@
 
 var _interopRequire = function (obj) { return obj && obj.__esModule ? obj["default"] : obj; };
 
+Object.defineProperty(exports, "__esModule", {
+	value: true
+});
+
 var amdMod = _interopRequire(require("basics/amdmodule"));
 
 exports["default"] = {
 	amdModule: amdMod,
 	name: "es6Module"
 };
-var __useDefault = exports.__useDefault = true;
-Object.defineProperty(exports, "__esModule", {
-	value: true
-});
+var __useDefault = true;
+exports.__useDefault = __useDefault;


### PR DESCRIPTION
This allows passing of es6 options to the Traceur/Babel compiler. Fixes #18