### PR TITLE
Set the export for globals

### DIFF
--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -7,6 +7,10 @@ module.exports = function(load){
 
 	var metaDeps = metadata.deps || [];
 	var deps = ["module", "@loader"].concat(metaDeps);
+	var exports = "false";
+	if(metadata.exports) {
+		exports = "\"" + metadata.exports + "\"";
+	}
 
 	var source = jsStringEscape(load.source);
 	var code = "define(\"" + name + "\", " + JSON.stringify(deps) +
@@ -21,7 +25,8 @@ module.exports = function(load){
         "  loader.__exec({'source': source, 'address': module.uri});\n" +
         "  loader.global.require = require;\n" +
         "  loader.global.define = define;\n" +
-		"\n  return loader.get(\"@@global-helpers\").retrieveGlobal(module.id, false);" +
+		"\n  return loader.get(\"@@global-helpers\").retrieveGlobal(module.id, " +
+		exports + ");" +
 		"\n});";
 
 	var ast = esprima.parse(code);

--- a/test/test.js
+++ b/test/test.js
@@ -162,7 +162,8 @@ describe('steal - amd', function(){
 
 describe('global - amd', function(){
     it('should work', function(done){
-		convert("global",global2amd,"global_amd.js", done);
+		var load = { metadata: { format: "global", exports: "GLOBAL" } };
+		convert("global",global2amd,"global_amd.js", {}, done, load);
     });
 });
 

--- a/test/tests/expected/global_amd.js
+++ b/test/tests/expected/global_amd.js
@@ -15,5 +15,5 @@ define('global', [
     });
     loader.global.require = require;
     loader.global.define = define;
-    return loader.get('@@global-helpers').retrieveGlobal(module.id, false);
+    return loader.get('@@global-helpers').retrieveGlobal(module.id, 'GLOBAL');
 });


### PR DESCRIPTION
For globals the `load.metadata.exports` string is used to specify the
name of the global module that is the correct exported value. We need to
pass this value into `retrieveGlobal` so that the multiExport logic
isn't applied.