### PR TITLE
Use all available options for globals

### DIFF
--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -11,14 +11,23 @@ module.exports = function(load){
 	if(metadata.exports) {
 		exports = "\"" + metadata.exports + "\"";
 	}
+	var preparedExportName = "";
+	if(metadata.exports) {
+		preparedExportName = exports;
+	} else if(metadata.init) {
+		preparedExportName = true;
+	}
 
 	var source = jsStringEscape(load.source);
 	var code = "define(\"" + name + "\", " + JSON.stringify(deps) +
 		", function(module, loader) {\n" +
-		"  loader.get(\"@@global-helpers\").prepareGlobal(module.id, []);\n" +
+		"  loader.get(\"@@global-helpers\").prepareGlobal(module.id, " +
+		JSON.stringify(metaDeps) + (preparedExportName ?
+									", " + preparedExportName : "") + ");\n" +
 		"  var define = loader.global.define;\n" +
         "  var require = loader.global.require;\n" +
 		"  var source = \"" + source + "\";\n" +
+		(metadata.init ? "  var init = " + metadata.init.toString() + ";\n" : "") +
         "  loader.global.define = undefined;\n" +
         "  loader.global.module = undefined;\n" +
         "  loader.global.exports = undefined;\n" +
@@ -26,7 +35,7 @@ module.exports = function(load){
         "  loader.global.require = require;\n" +
         "  loader.global.define = define;\n" +
 		"\n  return loader.get(\"@@global-helpers\").retrieveGlobal(module.id, " +
-		exports + ");" +
+		exports + (metadata.init ? ", init" : "") + ");" +
 		"\n});";
 
 	var ast = esprima.parse(code);

--- a/test/test.js
+++ b/test/test.js
@@ -165,6 +165,39 @@ describe('global - amd', function(){
 		var load = { metadata: { format: "global", exports: "GLOBAL" } };
 		convert("global",global2amd,"global_amd.js", {}, done, load);
     });
+
+	it("should include the export name", function(done){
+		var load = {
+			metadata: {
+				format: "global",
+				deps: ["foo"],
+				exports: "GLOBAL"
+			}
+		};
+		convert("global", global2amd, "global_amd_export.js", {}, done, load);
+	});
+
+	it("if no export is defined do not pass the exportname", function(done){
+		var load = {
+			metadata: {
+				format: "global",
+				deps: []
+			}
+		};
+		convert("global", global2amd, "global_amd_noexport.js", {}, done, load);
+	});
+
+	it("works with an init function passed", function(done){
+		var load = {
+			metadata: {
+				format: "global",
+				init: function(){
+					return window.FOO;
+				}
+			}
+		};
+		convert("global", global2amd, "global_amd_init.js", {}, done, load);
+	});
 });
 
 describe("transpile", function(){

--- a/test/tests/expected/global_amd_export.js
+++ b/test/tests/expected/global_amd_export.js
@@ -1,8 +1,9 @@
 define('global', [
     'module',
-    '@loader'
+    '@loader',
+    'foo'
 ], function (module, loader) {
-    loader.get('@@global-helpers').prepareGlobal(module.id, [], 'GLOBAL');
+    loader.get('@@global-helpers').prepareGlobal(module.id, ['foo'], 'GLOBAL');
     var define = loader.global.define;
     var require = loader.global.require;
     var source = 'var GLOBAL = "I don\'t like \\"Quotes\\"";';

--- a/test/tests/expected/global_amd_init.js
+++ b/test/tests/expected/global_amd_init.js
@@ -2,10 +2,13 @@ define('global', [
     'module',
     '@loader'
 ], function (module, loader) {
-    loader.get('@@global-helpers').prepareGlobal(module.id, [], 'GLOBAL');
+    loader.get('@@global-helpers').prepareGlobal(module.id, [], true);
     var define = loader.global.define;
     var require = loader.global.require;
     var source = 'var GLOBAL = "I don\'t like \\"Quotes\\"";';
+    var init = function () {
+        return window.FOO;
+    };
     loader.global.define = undefined;
     loader.global.module = undefined;
     loader.global.exports = undefined;
@@ -15,5 +18,5 @@ define('global', [
     });
     loader.global.require = require;
     loader.global.define = define;
-    return loader.get('@@global-helpers').retrieveGlobal(module.id, 'GLOBAL');
+    return loader.get('@@global-helpers').retrieveGlobal(module.id, false, init);
 });

--- a/test/tests/expected/global_amd_noexport.js
+++ b/test/tests/expected/global_amd_noexport.js
@@ -2,7 +2,7 @@ define('global', [
     'module',
     '@loader'
 ], function (module, loader) {
-    loader.get('@@global-helpers').prepareGlobal(module.id, [], 'GLOBAL');
+    loader.get('@@global-helpers').prepareGlobal(module.id, []);
     var define = loader.global.define;
     var require = loader.global.require;
     var source = 'var GLOBAL = "I don\'t like \\"Quotes\\"";';
@@ -15,5 +15,5 @@ define('global', [
     });
     loader.global.require = require;
     loader.global.define = define;
-    return loader.get('@@global-helpers').retrieveGlobal(module.id, 'GLOBAL');
+    return loader.get('@@global-helpers').retrieveGlobal(module.id, false);
 });


### PR DESCRIPTION
This adds a few things filling out all of the needs for globals.

* Fixes #40 by passing in the exportName to prepareGlobal. This will
avoid the expensive operation of copying all of the globals into a
temporary object.
* Passes in the dependencies into prepareGlobal so that they are set on
the window before eval.
* Passes in the init function to retrieveGlobal.

Also fixes #41 as there's a test for that now.