### PR TITLE
Babel, pass our override options last

### DIFF
--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -7,10 +7,10 @@ var mapFormat = {
 };
 
 module.exports = function(source, compileOptions, options){
-	var opts = assign({
+	var opts = assign({}, options.babelOptions, {
 		modules: mapFormat[compileOptions.modules],
 		sourceMap: compileOptions.sourceMaps || false
-	}, options.babelOptions);
+	});
 	if(opts.sourceMap) {
 		opts.sourceMapName = options.sourceMapFileName;
 		opts.sourceFileName = options.sourceMapFileName;


### PR DESCRIPTION
SystemJS sets some default babelOptions that we don't want (compile to
		System.register calls), so our overrides should be the last
thing passed to Object.assign before compiling.