### PR TITLE
update compileOptions override of traceurOptions to match how babelOptions works

### DIFF
--- a/lib/clean_traceur_compile.js
+++ b/lib/clean_traceur_compile.js
@@ -36,7 +36,7 @@ globalNames.forEach(function(name){
 	global[name] = oldGlobals[name];
 });
 
-module.exports = function(source, compilerOptions, options){
+module.exports = function(source, compileOptions, options){
 	var saved = {};
 	
 	globalNames.forEach(function(name){
@@ -44,16 +44,16 @@ module.exports = function(source, compilerOptions, options){
 		global[name] = globals[name];
 	});
 
-	if(compilerOptions.sourceMaps) {
-		compilerOptions.sourceMaps = "memory";
+	if(compileOptions.sourceMaps) {
+		compileOptions.sourceMaps = "memory";
 	}
 	if(options.traceurOptions) {
-		assign(compilerOptions, options.traceurOptions);
+		compileOptions = assign(options.traceurOptions, compileOptions);
 	}
-	var compiler = new NodeCompiler(commonJSOptions(compilerOptions));
+	var compiler = new NodeCompiler(commonJSOptions(compileOptions));
 
 	var result = {};
-	result.code = compiler.compile(source, compilerOptions.filename, compilerOptions.filename);
+	result.code = compiler.compile(source, compileOptions.filename, compileOptions.filename);
 	result.map = compiler.getSourceMap();
 	
 	globalNames.forEach(function(name){


### PR DESCRIPTION
Change needed for https://github.com/stealjs/steal-tools/pull/321.
