### PR TITLE
Properly support Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: node_js
 node_js:
   - 0.10
+  - 0.12
+  - 5.8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+# Test against this version of Node.js
+environment:
+  matrix:
+  # node.js
+  - nodejs_version: "5.8.0"
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+  - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm run test-windows
+
+# Don't actually build.
+build: off

--- a/lib/source_map_filename.js
+++ b/lib/source_map_filename.js
@@ -1,4 +1,5 @@
 var path = require("path");
+var urix = require("urix");
 
 module.exports = sourceMapFileName;
 
@@ -6,5 +7,5 @@ function sourceMapFileName(load, options){
 	var baseURL = options.baseURL || process.cwd();
 	var address = load.address.replace("file:", "");
 	var sourcePath = path.relative(baseURL, address);
-	return sourcePath;
+	return urix(sourcePath);
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name" : "transpile",
-  "description" : "Transpiles JavaScript modules from one format to another.",
-  "version" : "0.9.4",
-  "author" : {
-    "name" : "Bitovi",
-    "email" : "contact@bitovi.com",
-    "web" : "http://bitovi.com/"
+  "name": "transpile",
+  "description": "Transpiles JavaScript modules from one format to another.",
+  "version": "0.9.4",
+  "author": {
+    "name": "Bitovi",
+    "email": "contact@bitovi.com",
+    "web": "http://bitovi.com/"
   },
   "dependencies": {
     "babel-core": "5.8.14",
@@ -17,7 +17,8 @@
     "js-string-escape": "1.0.0",
     "object.assign": "^4.0.1",
     "sourcemap-to-ast": "0.0.2",
-    "traceur": "0.0.91"
+    "traceur": "0.0.91",
+    "urix": "^0.1.0"
   },
   "devDependencies": {
     "chai": "*",
@@ -37,7 +38,8 @@
   },
   "scripts": {
     "mocha": "mocha test/*.js",
-    "test": "./node_modules/istanbul/lib/cli.js cover -- ./node_modules/.bin/_mocha test/*.js --reporter spec"
+    "test": "./node_modules/istanbul/lib/cli.js cover -- ./node_modules/.bin/_mocha test/*.js --reporter spec",
+    "test-windows": "node_modules\\.bin\\mocha test\\*.js --reporter spec"
   },
   "licenses": [
     {


### PR DESCRIPTION
This fixes a source mapping issue where we were using filesystem path
separators in the source maps "sources" property, whereas those should
be http paths, which are always unixy.

Also adds CI for Windows.