### PR TITLE
Add support for commonjs global and __dirname

### DIFF
--- a/lib/cjs_amd.js
+++ b/lib/cjs_amd.js
@@ -7,8 +7,19 @@ var esprima = require('esprima'),
 	getAst = require("./get_ast"),
 	estraverse = require("estraverse");
 
+var dirnameExp = /__dirname/;
+var globalExp = /global\./;
+
 module.exports = function(load, options){
 	var ast = getAst(load);
+
+	var source = load.source;
+	var cjsOptions = {
+		hasDirname: dirnameExp.test(source),
+		hasGlobal: globalExp.test(source)
+	};
+	cjsOptions.needsFunctionWrapper = cjsOptions.hasDirname ||
+		cjsOptions.hasGlobal;
 
 	// If we need to normalize then we must use esprima.
 	if(options && (options.normalizeMap || options.normalize)) {
@@ -35,28 +46,34 @@ module.exports = function(load, options){
 	if(options.namedDefines) {
 		normalizedName = optionsNormalize(options, load.name, load.name, load.address);
 	}
-	var ast = defineInsert(normalizedName, ast.body);
+	var ast = defineInsert(normalizedName, ast.body, cjsOptions);
 
 	return ast;
 };
 
 
-function defineInsert(name, body) {
+function defineInsert(name, body, options) {
+	// Add in the function wrapper.
+	var wrapper = defineWrapper(options);
+
 	var named = name ? ("'" + name + "', ") : "";
 	var code = "define(" + named +
 		"function(require, exports, module) {\n" +
+		wrapper +
 		"\n});";
 
 	var ast = esprima.parse(code);
 	body = body || [];
 
-	var isFunction;
+	var innerFunctions = 0;
+	var expectedFunctions = options.needsFunctionWrapper ? 2 : 1;
 	estraverse.traverse(ast, {
 		enter: function(node) {
 			if(node.type === "FunctionExpression") {
-				isFunction = true;
+				innerFunctions++;
 			}
-			if(isFunction && node.type === "BlockStatement") {
+			if(innerFunctions === expectedFunctions &&
+			   node.type === "BlockStatement") {
 				body.forEach(function(part){
 					node.body.push(part);
 				});
@@ -66,4 +83,36 @@ function defineInsert(name, body) {
 	});
 
 	return ast;
+}
+
+function defineWrapper(options) {
+	// Add in the function wrapper.
+	var wrapper = "";
+	if(options.needsFunctionWrapper) {
+		wrapper += "(function(";
+		if(options.hasGlobal) {
+			wrapper += "global";
+		}
+		if(options.hasGlobal && options.hasDirname) {
+			wrapper += ", ";
+		}
+		if(options.hasDirname) {
+			wrapper += "__dirname";
+		}
+		wrapper += "){\n";
+		wrapper += "})(";
+
+		if(options.hasGlobal) {
+			wrapper += "function() { return this; }()";
+		}
+		if(options.hasGlobal && options.hasDirname) {
+			wrapper += ", ";
+		}
+		if(options.hasDirname) {
+			wrapper += '"/"';
+		}
+		wrapper += ");";
+	}
+
+	return wrapper;
 }

--- a/test/test.js
+++ b/test/test.js
@@ -331,6 +331,15 @@ describe('cjs - amd', function(){
 
 		convert("cjs_deps", cjs2amd, "cjs_deps_named_defines.js", options, done);
 	});
+	it('converts a module that uses global', function(done){
+		convert("cjs_global", cjs2amd, "cjs_global.js", done);
+	});
+	it('converts a module that uses __dirname', function(done){
+		convert("cjs_dirname", cjs2amd, "cjs_dirname.js", done);
+	});
+	it('converts a module that uses global and __dirname', function(done){
+		convert("cjs_global_dirname", cjs2amd, "cjs_global_dirname.js", done);
+	});
 });
 
 describe('normalize options', function(){

--- a/test/tests/cjs_dirname.js
+++ b/test/tests/cjs_dirname.js
@@ -1,0 +1,1 @@
+var p = __dirname + "/foo";

--- a/test/tests/cjs_global.js
+++ b/test/tests/cjs_global.js
@@ -1,0 +1,3 @@
+global.setTimeout(function(){
+
+});

--- a/test/tests/cjs_global_dirname.js
+++ b/test/tests/cjs_global_dirname.js
@@ -1,0 +1,2 @@
+var Math = global.Math;
+var p = __dirname + "/foo";

--- a/test/tests/expected/cjs_dirname.js
+++ b/test/tests/expected/cjs_dirname.js
@@ -1,0 +1,5 @@
+define(function (require, exports, module) {
+    (function (__dirname) {
+        var p = __dirname + '/foo';
+    }('/'));
+});

--- a/test/tests/expected/cjs_global.js
+++ b/test/tests/expected/cjs_global.js
@@ -1,0 +1,8 @@
+define(function (require, exports, module) {
+    (function (global) {
+        global.setTimeout(function () {
+        });
+    }(function () {
+        return this;
+    }()));
+});

--- a/test/tests/expected/cjs_global_dirname.js
+++ b/test/tests/expected/cjs_global_dirname.js
@@ -1,0 +1,8 @@
+define(function (require, exports, module) {
+    (function (global, __dirname) {
+        var Math = global.Math;
+        var p = __dirname + '/foo';
+    }(function () {
+        return this;
+    }(), '/'));
+});


### PR DESCRIPTION
This adds support for CommonJS transpilation that includes a wrapper for
when using `global` or `__dirname`. This is a self-executing function
wrapper.

Closes #32