### PR TITLE
use babel 6.13 and the built-in transformation to AMD or CommonJS

### DIFF
--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -7,9 +7,9 @@ module.exports = function(source, compileOptions, options){
 	});
 
 	opts.presets = opts.presets || [
-		["es2015", {"loose": false, "modules": compileOptions.modules}],
-		"babel-preset-react",
-		"babel-preset-stage-0"
+		require("babel-preset-es2015").buildPreset({},{"loose": false, "modules": compileOptions.modules}),
+		require("babel-preset-react"),
+		require("babel-preset-stage-0")
 	];
 	opts.plugins = opts.plugins || [];
 

--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -1,23 +1,17 @@
 var babel = require("babel-core");
 var assign = require('object.assign');
 
-var mapPlugin = {
-	'commonjs': 'babel-plugin-transform-es2015-modules-commonjs',
-	'amd': 'babel-plugin-transform-es2015-modules-amd'
-};
-
 module.exports = function(source, compileOptions, options){
 	var opts = assign({}, options.babelOptions, {
 		sourceMap: compileOptions.sourceMaps || false
 	});
 
 	opts.presets = opts.presets || [
-		require("babel-preset-es2015-no-commonjs"),
-		require("babel-preset-react"),
-		require("babel-preset-stage-0")
+		["es2015", {"loose": false, "modules": compileOptions.modules}],
+		"babel-preset-react",
+		"babel-preset-stage-0"
 	];
 	opts.plugins = opts.plugins || [];
-	opts.plugins.push(require(mapPlugin[compileOptions.modules]));
 
 	// Remove Babel 5 options
 	delete opts.optional;

--- a/package.json
+++ b/package.json
@@ -8,10 +8,8 @@
     "web": "http://bitovi.com/"
   },
   "dependencies": {
-    "babel-core": "6.9.1",
-    "babel-plugin-transform-es2015-modules-amd": "^6.4.3",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.4.5",
-    "babel-preset-es2015-no-commonjs": "0.0.2",
+    "babel-core": "^6.13.0",
+    "babel-preset-es2015": "^6.13.0",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "comparify": "0.1.0",


### PR DESCRIPTION
this PR updates to babel 6.13 and use the built-in transformation to other module formats.

remove the transformation plugins and the babel preset without commonjs `babel-preset-es2015-no-commonjs`

this PR does not fix any knowing bugs, just refactoring

@matthewp dont think this PR affected steal and steal-tools?