### PR TITLE
Remove customPlugins support

### DIFF
--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -17,15 +17,6 @@ module.exports = function(source, compileOptions, options){
 	opts.presets = defaultPresets.concat(opts.presets || []);
 	opts.plugins = opts.plugins || [];
 
-	// register plugins not bundled in babel-standalone
-	if (opts.customPlugins) {
-		Object.keys(opts.customPlugins).forEach(function(name) {
-			babel.registerPlugin(name, opts.customPlugins[name]);
-		});
-
-		delete opts.customPlugins;
-	}
-
 	// Remove Babel 5 options
 	delete opts.optional;
 	delete opts.whitelist;

--- a/test/test.js
+++ b/test/test.js
@@ -314,10 +314,7 @@ describe('es6 - amd', function(){
 		doTranspile("es6", "es6", "es6_amd_babel_and_plugin.js", "amd", {
 			transpiler: "babel",
 			babelOptions: {
-				plugins: ["my-custom-plugin"],
-				customPlugins: {
-					"my-custom-plugin": require("./babel-plugin")
-				}
+				plugins: [ require("./babel-plugin") ]
 			}
 		}, done);
 	});


### PR DESCRIPTION
The current approach is to pass the function of non-builtins in the `plugins` array.