### PR TITLE
Refactor package entry module

### DIFF
--- a/lib/bfs.js
+++ b/lib/bfs.js
@@ -1,36 +1,41 @@
-// from https://github.com/adlawson/bfs-js/blob/master/bfs.js
-module.exports = (function () {
+/**
+ * Visitor function called on each node
+ * @callback visitor
+ * @param {{}} node The node being visited, it is augmented with the path (an
+ *                  array of nodes, that leads to it)
+ */
 
-    'use strict';
+/**
+ * Graph visitor based on the the https://en.wikipedia.org/wiki/Breadth-first_search
+ *
+ * @param {{}} startNode The node where the search/traverse starts
+ * @param {Array} graph The graph to be traversed
+ * @callback {visitor} fn A function called on each node
+ */
+module.exports = function bfs(startNode, graph, fn) {
+	visit([{ node: startNode, path: [] }], graph, fn);
+};
 
-    function visit(frontier, graph, fn) {
-        var level = 0;
-        var levels = {};
+function visit(frontier, graph, fn) {
+	var level = 0;
+	var levels = {};
 
-        while (0 < frontier.length) {
-            var next = [];
-            for (var i = 0; i < frontier.length; i++) {
-                var cur = frontier[i];
-                var node = cur.node;
-                if(fn(cur) === false){
-                  return;
-                }
-                levels[node] = level;
-                for (var adj in graph[node]) {
-                    if (typeof levels[adj] === 'undefined') {
-                        next.push({node: adj, path: cur.path.concat(node)});
-                    }
-                }
-            }
-            frontier = next; // eslint-disable-line no-param-reassign
-            level += 1;
-        }
-    }
-
-    function bfs(node, graph, fn) {
-        visit([{node: node, path: []}], graph, fn);
-    }
-
-    return bfs;
-
-})();
+	while (0 < frontier.length) {
+		var next = [];
+		for (var i = 0; i < frontier.length; i++) {
+			var cur = frontier[i];
+			var node = cur.node;
+			if (fn(cur) === false) {
+				return;
+			}
+			levels[node] = level;
+			for (var adj in graph[node]) {
+				if (typeof levels[adj] === "undefined") {
+					next.push({ node: adj, path: cur.path.concat(node) });
+				}
+			}
+		}
+		frontier = next; // eslint-disable-line no-param-reassign
+		level += 1;
+	}
+}

--- a/lib/make_transforms_formats_graph.js
+++ b/lib/make_transforms_formats_graph.js
@@ -1,0 +1,47 @@
+/**
+ * Creates a graph of supported format transforms
+ *
+ * @param {Array<string>} transforms An array of supported transformations
+ *                        with the shape `formatA_formatB`; where formatA is
+ *                        the source format and formatB the destination format
+ * @return {Object} A graph of supported transformations, e.g:
+ *
+ * ```
+ * {
+ *   amd: { cjs: {} },
+ *   cjs: { steal: {} },
+ *   steal: {}
+ * }
+ * ```
+ *
+ * The graph above indicates that's possible to transform from `amd` to `cjs`,
+ * and from `cjs` to the `steal` format.
+ */
+module.exports = function(transforms) {
+	var graph = makeEmptyGraph();
+
+	transforms.forEach(function(transform) {
+		var parts = transform.split("_");
+
+		var source = parts[0];
+		var dest = parts[1];
+
+		graph[source] = graph[source] || makeEmptyGraph();
+		graph[dest] = graph[dest] || makeEmptyGraph();
+
+		if (source === dest) {
+			// Prevent duplicating `graph[source]` in `graph[source][dest]`
+			graph[source][dest] = makeEmptyGraph();
+		}
+		else {
+			// use a shallow clone of `graph[dest]` to avoid a recursive graph
+			graph[source][dest] = Object.assign({}, graph[dest]);
+		}
+	});
+
+	return graph;
+};
+
+function makeEmptyGraph() {
+	return Object.create(null);
+}

--- a/main.js
+++ b/main.js
@@ -1,81 +1,63 @@
 var bfs = require("./lib/bfs");
-var detect = require('js-module-formats').detect;
+var detect = require("js-module-formats").detect;
 var generate = require("./lib/generate");
 var getAst = require("./lib/get_ast");
 var sourceMapFileName = require("./lib/source_map_filename");
-var graph = {},
-	transpilers = {
-		"amd_cjs": require("./lib/amd_cjs"),
-		"cjs_amd": require("./lib/cjs_amd"),
-		"cjs_steal": require("./lib/cjs_steal"),
-		"es6_amd": require("./lib/es6_amd"),
-		"es6_cjs": require("./lib/es6_cjs"),
-		"steal_amd": require("./lib/steal_amd"),
-		"amd_amd": require("./lib/amd_amd"),
-		"global_amd": require("./lib/global_amd"),
-		"cjs_cjs": require("./lib/cjs_cjs")
-	};
+var makeFormatsGraph = require("./lib/make_transforms_formats_graph.js");
 
-for(var edge in transpilers) {
-	var types = edge.split("_");
-
-	if(!graph[types[0]]) {
-		graph[types[0]] = {};
-	}
-	if(!graph[types[1]]) {
-		graph[types[1]] = {};
-	}
-
-	graph[types[0]][types[1]] = graph[types[1]];
-}
-
-
-
-var copyLoad = function(load){
-	var copy = {};
-	for(var prop in load){
-		copy[prop] = load[prop];
-	}
-	return copy;
+var transpilers = {
+	"amd_cjs": require("./lib/amd_cjs"),
+	"cjs_amd": require("./lib/cjs_amd"),
+	"cjs_steal": require("./lib/cjs_steal"),
+	"es6_amd": require("./lib/es6_amd"),
+	"es6_cjs": require("./lib/es6_cjs"),
+	"steal_amd": require("./lib/steal_amd"),
+	"amd_amd": require("./lib/amd_amd"),
+	"global_amd": require("./lib/global_amd"),
+	"cjs_cjs": require("./lib/cjs_cjs")
 };
+
+var formatsTransformsGraph = makeFormatsGraph(Object.keys(transpilers));
 
 var toSelf = function(load){
 	return load.ast;
 };
 
-
 function moduleType(source) {
 	var type = detect(source);
 	// tricky, since the detected type could be just `es` instead of `es6`.
-	return type && type !== 'es' ? type : 'es6';
+	return type && type !== "es" ? type : "es6";
 }
 
 // transpile.to
 var transpile = {
 	transpilers: transpilers,
-	// transpile.to("amd",load)
-	to: function(load, type, options){
-		var format = load.metadata.format || moduleType(load.source);
-		var path = this.able(format, type);
+	to: function(load, destFormat, options){
+		var sourceFormat = load.metadata.format || moduleType(load.source);
+		var path = this.able(sourceFormat, destFormat);
 
 		if(!path) {
-			throw "transpile - unable to transpile "+format+" to "+type;
+			throw new Error(`
+				transpile - unable to transpile ${sourceFormat} to ${destFormat}
+			`);
 		}
+
+		// the source format and the dest format are the same, e.g: cjs_cjs
+		// Check for a transpiler
 		if(!path.length) {
-			// we are transpiling to ourselves.  Check for a transpiler
-			path.push(format);
+			path.push(sourceFormat);
 		}
 
-		path.push(type);
+		path.push(destFormat);
 
-		var copy = copyLoad(load);
+		var copy = Object.assign({}, load);
 		var normalize = options.normalize;
 
 		var transpileOptions = options || {};
 		transpileOptions.sourceMapFileName = sourceMapFileName(copy, options);
 
 		// Create the initial AST
-		if(format !== "es6") {
+		if(sourceFormat !== "es6") {
 			copy.ast = getAst(copy, transpileOptions.sourceMapFileName);
 		}
 
@@ -90,9 +72,16 @@ var transpile = {
 		transpileOptions.normalize = normalize;
 		return generate(copy.ast, options, sourceContent);
 	},
+	/**
+	 * Whether it's possible to transform the source format to the dest format
+	 * @param {string} from The format of the source, e.g: "es6"
+	 * @parem {string} to the format of the output code, e.g: "amd"
+	 * @return {?Array} The "path" of formats needed to transform
+	 *                  from the source code to the dest format
+	 */
 	able: function(from, to) {
 		var path;
-		bfs(from || "es6", graph, function(cur){
+		bfs(from || "es6", formatsTransformsGraph, function(cur){
 			if(cur.node === to) {
 				path = cur.path;
 				return false;

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     },
     "env": {
       "node": true,
-      "mocha": true
+      "mocha": true,
+      "es6": true
     }
   }
 }

--- a/test/make_formats_graph.js
+++ b/test/make_formats_graph.js
@@ -1,0 +1,62 @@
+var assert = require("assert");
+var makeFormatsGraph = require("../lib/make_transforms_formats_graph.js");
+
+describe("makeFormatsGraph", function() {
+	it("one transform", function() {
+		assert.deepEqual(makeFormatsGraph(["amd_cjs"]), {
+			amd: { cjs: {} },
+			cjs: {}
+		});
+	});
+
+	it("two (independent) transforms", function() {
+		assert.deepEqual(makeFormatsGraph(["amd_cjs", "es6_steal"]), {
+			amd: { cjs: {} },
+			es6: { steal: {} },
+			steal: {},
+			cjs: {}
+		});
+	});
+
+	it("two linked transforms", function() {
+		assert.deepEqual(makeFormatsGraph(["amd_cjs", "cjs_steal"]), {
+			amd: { cjs: {} },
+			cjs: { steal: {} },
+			steal: {}
+		});
+	});
+
+	it("two transforms from the same source", function() {
+		assert.deepEqual(makeFormatsGraph(["amd_cjs", "amd_steal"]), {
+			amd: { cjs: {}, steal: {} },
+			cjs: {},
+			steal: {}
+		});
+	});
+
+	it("two cyclic transforms", function() {
+		assert.deepEqual(makeFormatsGraph(["amd_cjs", "cjs_amd"]), {
+			amd: { cjs: {} },
+			cjs: { amd: { cjs: {} } }
+		});
+	});
+
+	it("self to self transform", function() {
+		assert.deepEqual(makeFormatsGraph(["amd_cjs", "cjs_cjs"]), {
+			amd: { cjs: {} },
+			cjs: { cjs: {} }
+		});
+	});
+
+	it("prevent nested duplicated format nodes", function() {
+		assert.deepEqual(makeFormatsGraph(["cjs_amd", "cjs_steal", "cjs_cjs"]), {
+			"amd": {},
+			"cjs": {
+				"amd": {},
+				"cjs": {},
+				"steal": {}
+			},
+			"steal": {}
+		});
+	});
+});


### PR DESCRIPTION
I was having some trouble following transpile's entry module code and decided to document some things, re-org some code and add a few tests.

😅 

- Document the `bfs` module
- Document `transpile.able`
- Move logic to create formats graph into its own module (and test it)
- Remove some custom function in favor of built in JS functions