### PR TITLE
Use `ast-types` to traverse tree in cjs_amd

### DIFF
--- a/lib/cjs_amd.js
+++ b/lib/cjs_amd.js
@@ -1,10 +1,9 @@
 "format cjs";
-var esprima = require('esprima'),
-	traverse = require('./traverse'),
-	comparify = require('comparify'),
-	optionsNormalize = require('./options_normalize'),
+var esprima = require("esprima"),
+	optionsNormalize = require("./options_normalize"),
 	getAst = require("./get_ast"),
-	estraverse = require("estraverse");
+	types = require("ast-types"),
+	n = types.namedTypes;
 
 var dirnameExp = /__dirname/;
 var globalExp = /global/;
@@ -20,27 +19,10 @@ module.exports = function(load, options){
 	cjsOptions.needsFunctionWrapper = cjsOptions.hasDirname ||
 		cjsOptions.hasGlobal;
 
-	// If we need to normalize then we must use esprima.
-	if(options && (options.normalizeMap || options.normalize)) {
-		traverse(ast, function(obj){
-			if(comparify(obj, {
-				"type": "CallExpression",
-				"callee": {
-					"type": "Identifier",
-					"name": "require"
-				}
-			})) {
-				var arg = obj.arguments[0];
-				if(arg.type === "Literal") {
-					var val = arg.value;
-					arg.value = optionsNormalize(options, val, load.name, load.address);
-					arg.raw = '"'+arg.value+'"';
-				}
-
-				return false;
-			}
-		});
+	if (options && (options.normalizeMap || options.normalize)) {
+		normalizeModuleIdentifiers(ast, load, options);
 	}
+
 	var normalizedName;
 	if(options.namedDefines) {
 		normalizedName = optionsNormalize(options, load.name, load.name, load.address);
@@ -50,38 +32,81 @@ module.exports = function(load, options){
 	return ast;
 };
 
+/**
+ * Traverses the AST (CJS) and normalizes the module identifiers
+ */
+function normalizeModuleIdentifiers(ast, load, options) {
+	types.visit(ast, {
+		visitCallExpression: function(path) {
+			var node = path.node;
+
+			if (this.isRequireExpression(node)) {
+				var arg = path.getValueProperty("arguments")[0];
+
+				if (n.Literal.check(arg)) {
+					var identifier = types.getFieldValue(arg, "value");
+					var normalized = optionsNormalize(options, identifier,
+						load.name, load.address);
+
+					arg.value = normalized;
+					arg.raw = `"${normalized}"`;
+				}
+
+				return false;
+			}
+
+			this.traverse(path);
+		},
+
+		isRequireExpression(node) {
+			return n.Identifier.check(node.callee) &&
+				node.callee.name === "require";
+		}
+	});
+}
+
 
 function defineInsert(name, body, options) {
 	// Add in the function wrapper.
 	var wrapper = defineWrapper(options);
-
-	var named = name ? ("'" + name + "', ") : "";
-	var code = "define(" + named +
-		"function(require, exports, module) {\n" +
-		wrapper +
-		"\n});";
+	var code = makeDefineFunctionCode(name, wrapper);
 
 	var ast = esprima.parse(code);
 	var astBody = body || [];
 
 	var innerFunctions = 0;
 	var expectedFunctions = options.needsFunctionWrapper ? 2 : 1;
-	estraverse.traverse(ast, {
-		enter: function(node) {
-			if(node.type === "FunctionExpression") {
-				innerFunctions++;
-			}
-			if(innerFunctions === expectedFunctions &&
-				node.type === "BlockStatement") {
-				astBody.forEach(function(part){
-					node.body.push(part);
+
+	types.visit(ast, {
+		visitFunctionExpression: function(path) {
+			if (this.isModuleFactory()) {
+				var functionBody = path.getValueProperty("body").body;
+
+				astBody.forEach(function(part) {
+					functionBody.push(part);
 				});
-				this.break();
+
+				// stop traversing the tree
+				this.abort();
 			}
+
+			// keep traversing the tree
+			this.traverse(path);
+		},
+
+		isModuleFactory: function() {
+			innerFunctions += 1;
+			return innerFunctions === expectedFunctions;
 		}
 	});
 
 	return ast;
+}
+
+function makeDefineFunctionCode(name, body) {
+	return name ?
+		`define('${name}', function(require, exports, module) { ${body} });` :
+		`define(function(require, exports, module) { ${body} })`;
 }
 
 function defineWrapper(options) {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "web": "http://bitovi.com/"
   },
   "dependencies": {
+    "ast-types": "^0.9.11",
     "babel-standalone": "^6.23.1",
     "comparify": "0.2.0",
     "escodegen": "^1.7.0",


### PR DESCRIPTION
@matthewp  I wanted to give it a try (in a tested module) before using it in the slim format. What do you think?

I like it, also ❤️   for removing the `comparify`, `traverse` and `estraverse` requires! \ :D / 