### PR TITLE
fix global meta option not working when transpiled

### DIFF
--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -32,12 +32,12 @@ module.exports = function(load){
 		"  });\n" +
 		"  var define = loader.global.define;\n" +
         "  var require = loader.global.require;\n" +
-		"  var source = \"" + source + "\";\n" +
+		"  var source = \"" + (metadata.exports ? (source + 'this[\'' + metadata.exports + '\'] = ' + metadata.exports) : source)  +  "\";\n" +
 		(metadata.init ? "  var init = " + metadata.init.toString() + ";\n" : "") +
         "  loader.global.define = undefined;\n" +
         "  loader.global.module = undefined;\n" +
         "  loader.global.exports = undefined;\n" +
-        "  loader.__exec({'source': source, 'address': module.uri});\n" +
+        "  loader.__exec({'source': source, 'address': module.uri, 'metadata': {'eval': '" + (metadata.eval || '') +  "'} });\n" +
         "  loader.global.require = require;\n" +
         "  loader.global.define = define;\n" +
 		"\n  return loader.get(\"@@global-helpers\").retrieveGlobal(module.id, " +


### PR DESCRIPTION
fix bug when stealjs has global meta option with exports and eval setup, works fine when in dev mode but not working after transpiled

after this patch, the eval type of script works, and exports has correct result