### PR TITLE
Breaking test for ES6 -> AMD import order issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "ast-types": "^0.9.11",
-    "babel-standalone": "^6.23.1",
+    "babel-standalone": "^6.26.0",
     "comparify": "0.2.0",
     "escodegen": "^1.7.0",
     "esprima": "^4.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -419,6 +419,16 @@ describe("es6 - amd", function() {
 			expectedFileName: "es6_amd_babel_circular"
 		});
 	});
+
+	it.only("does not change order of empty imports", function() {
+		return doTranspile({
+			moduleFormat: "es6",
+			resultModuleFormat: "amd",
+			options: { transpiler: "babel" },
+			sourceFileName: "es6_empty_import_first",
+			expectedFileName: "es6_empty_import_first_amd"
+		});
+	});
 });
 
 describe("normalize options", function() {

--- a/test/tests/es6_empty_import_first.js
+++ b/test/tests/es6_empty_import_first.js
@@ -1,0 +1,6 @@
+import "./a";
+import b from "./b";
+
+export default function() {
+	return b;
+}

--- a/test/tests/expected/es6_empty_import_first_amd.js
+++ b/test/tests/expected/es6_empty_import_first_amd.js
@@ -1,0 +1,15 @@
+define([
+    'exports',
+    './a'
+    './b',
+], function (exports, null, _b) {
+    'use strict';
+    Object.defineProperty(exports, '__esModule', { value: true });
+    exports.default = function () {
+        return _b2.default;
+    };
+    var _b2 = _interopRequireDefault(_b);
+    function _interopRequireDefault(obj) {
+        return obj && obj.__esModule ? obj : { default: obj };
+    }
+});


### PR DESCRIPTION
Ref: https://github.com/stealjs/steal-tools/issues/804


Had this changes stashed, will keep this PR open to make sure babel-standalone@7 fixes the problem once is released.
