### PR TITLE
Handle nested define in amd -> slim transform

### DIFF
--- a/lib/amd/slim.js
+++ b/lib/amd/slim.js
@@ -1,3 +1,4 @@
+
 var types = require("ast-types");
 var getAst = require("../get_ast");
 var assign = require("lodash/assign");
@@ -12,15 +13,98 @@ module.exports = function(load, options) {
 	var slimAst;
 	var currentAst = getAst(load);
 
-	// handle jQuery-like IIFE/amd modules
-	if (isIifeAst(currentAst)) {
-		return slimBuilder.makeAstFromIife(
+	// handle UMD-like modules where `define` is nested  and there is a
+	// check for the `define.amd` property
+	if (hasNestedDefine(currentAst) && hasDefineAmdReference(currentAst)) {
+		slimAst = slimBuilder.makeAstFromNestedDefine(
 			load.uniqueId || load.name,
-			currentAst.body[0]
+			currentAst.body
+		);
+	} else {
+		slimAst = makeAstFromTopLevelDefine(load, options, currentAst);
+	}
+
+	if (!slimAst) {
+		throw new Error(
+			[
+				`Unable to transpile ${load.name} to slim format`,
+				"Could not find AMD's `define` function call"
+			].join("\n")
 		);
 	}
 
-	types.visit(currentAst, {
+	return slimAst;
+};
+
+/**
+ * Whether there is a non top level `define` function call in the AST
+ * @param {Object} ast - The AST to be checked
+ * @return {boolean}
+ */
+function hasNestedDefine(ast) {
+	var result = false;
+
+	types.visit(ast, {
+		visitCallExpression: function(path) {
+			if (this.isDefineExpression(path)) {
+				result = true;
+				this.abort();
+			}
+
+			this.traverse(path);
+		},
+
+		// whether a non top level `define(` is call in the AST
+		isDefineExpression: function(path) {
+			return (
+				n.Identifier.check(path.node.callee) &&
+				path.node.callee.name === "define" &&
+				!n.Program.check(path.parent.parent.node)
+			);
+		}
+	});
+
+	return result;
+}
+
+/**
+ * Whether there is a `define.amd` member expression on the AST
+ * @param {Object} ast - The AST to be checked
+ * @return {boolean}
+ */
+function hasDefineAmdReference(ast) {
+	var result = false;
+
+	types.visit(ast, {
+		visitMemberExpression: function(path) {
+			if (this.isDefineAmd(path.node)) {
+				result = true;
+				this.abort();
+			}
+
+			this.traverse(path);
+		},
+
+		isDefineAmd: function(node) {
+			return (
+				n.Identifier.check(node.object) &&
+				node.object.name === "define" &&
+				n.Identifier.check(node.property) &&
+				node.property.name === "amd"
+			);
+		}
+	});
+
+	return result;
+}
+
+/**
+ * Return the slim version of the provided AST
+ */
+function makeAstFromTopLevelDefine(load, options, ast) {
+	var slimAst;
+
+	types.visit(ast, {
 		visitCallExpression: function(path) {
 			if (this.isAmd(path)) {
 				var args = this.getAmdDefineArguments(
@@ -152,21 +236,18 @@ module.exports = function(load, options) {
 			}
 
 			// set the `isCjsWrapper` flag
-			result.isCjsWrapper = n.ArrayExpression.check(result.dependencies) &&
+			result.isCjsWrapper =
+				n.ArrayExpression.check(result.dependencies) &&
 				result.dependencies.elements.length
-				? this.usesCjsRequireExports(result.dependencies)
-				: this.isCjsSimplifiedWrapper(result.factory);
+					? this.usesCjsRequireExports(result.dependencies)
+					: this.isCjsSimplifiedWrapper(result.factory);
 
 			return result;
 		}
 	});
 
-	if (!slimAst) {
-		throw new Error(`Unable to transpile ${load.name}`);
-	}
-
 	return slimAst;
-};
+}
 
 /**
  * Normalizes the factory function if the object shorthand was used
@@ -178,20 +259,6 @@ function getFactory(arg) {
 	return n.ObjectExpression.check(arg)
 		? slimBuilder.makeFactoryFromObject(arg)
 		: arg;
-}
-
-/**
- * Whether the AST matches a top-level immediately invoked function expression
- * @param {Object} ast - The load's ast property
- * @return {boolean} - `true` if the ast matches a top level IIFE, `false` otherwise.
- */
-function isIifeAst(ast) {
-	return (
-		ast.body.length === 1 &&
-		n.ExpressionStatement.check(ast.body[0]) &&
-		n.CallExpression.check(ast.body[0].expression) &&
-		n.FunctionExpression.check(ast.body[0].expression.callee)
-	);
 }
 
 function needsNormalize(dependencies, options) {
@@ -221,3 +288,4 @@ function normalizeDependencies(load, options, dependencies) {
 
 	return clone;
 }
+

--- a/lib/amd/slim_builder.js
+++ b/lib/amd/slim_builder.js
@@ -34,28 +34,26 @@ module.exports = {
 	},
 
 	/**
-	 * AST template of the shim used in jQuery-like IIFE/amd modules
-	 * @return {Function} Returns the full AST tree, being Program the root node.
+	 * AST template of the shim used in UMD-like modules
+	 * Each helper returns the full AST being Program at the root of the tree.
 	 */
-	amdIifeShimStart: estemplate.compile(`
-		window.__defineNoConflict = window.define;
-		window.define = function() {
-			var factory = arguments[arguments.length - 1];
+	amdDefineShim: {
+		start: estemplate.compile(`
+			window.__defineNoConflict = window.define;
+			window.define = function() {
+				var factory = arguments[arguments.length - 1];
 
-			stealModule.exports = (typeof factory === "function") ?
-				factory() : factory;
-		};
-		define.amd = true;
-	`),
+				stealModule.exports = (typeof factory === "function") ?
+					factory() : factory;
+			};
+			define.amd = true;
+		`),
 
-	/**
-	 * AST template of the end part of the shim used in jQuery-like IIFE/amd
-	 * @return {Function} Returns the full AST tree, being Program the root node.
-	 */
-	amdIifeShimEnd: estemplate.compile(`
-		window.define = __defineNoConflict;
-		window.__defineNoConflict = undefined;
-	`),
+		end: estemplate.compile(`
+			window.define = __defineNoConflict;
+			window.__defineNoConflict = undefined;
+		`)
+	},
 
 	makeAst: function(defineArguments) {
 		var id = defineArguments.id;
@@ -93,19 +91,19 @@ module.exports = {
 	},
 
 	/**
-	 * Returns the slim node AST from an immediately invoked function expression
+	 * Returns the slim node AST from an UMD-like module with a nested define
 	 * @param {string} moduleId - The module's id
-	 * @param {Object} expressionStatement - The IIFE top level node
+	 * @param {Object} programBody - The AST top level body array
 	 * @return {Object} The slim node AST
 	 */
-	makeAstFromIife: function(moduleId, expressionStatement) {
+	makeAstFromNestedDefine: function(moduleId, programBody) {
 		return this.slimWrapperTemplate({
 			moduleId: b.literal(moduleId),
 			params: this.slimFunctionParams[3],
 			body: concat(
-				this.amdIifeShimStart({}).body,
-				expressionStatement,
-				this.amdIifeShimEnd({}).body
+				this.amdDefineShim.start({}).body,
+				programBody,
+				this.amdDefineShim.end({}).body
 			)
 		});
 	},

--- a/test/amd_slim.js
+++ b/test/amd_slim.js
@@ -124,4 +124,12 @@ describe("amd - slim", function() {
 			}
 		});
 	});
+
+	it("transpiles UMD modules", function() {
+		return convert({
+			converter: amdToSlim,
+			sourceFileName: "amd_umd",
+			expectedFileName: "amd_umd_slim"
+		});
+	});
 });

--- a/test/tests/amd_umd.js
+++ b/test/tests/amd_umd.js
@@ -1,0 +1,19 @@
+var _ = Object.create(null);
+
+_.each = function() {};
+_.clone = function() {};
+
+if (
+  typeof define == "function" &&
+  typeof define.amd == "object" &&
+  define.amd
+) {
+  define(function() {
+    return _;
+  });
+} else if (freeModule) {
+  // Export for Node.js.
+  (freeModule.exports = _)._ = _;
+  // Export for CommonJS support.
+  freeExports._ = _;
+}

--- a/test/tests/expected/amd_umd_slim.js
+++ b/test/tests/expected/amd_umd_slim.js
@@ -1,0 +1,26 @@
+[
+    'amd_umd',
+    function (stealRequire, stealExports, stealModule) {
+        window.__defineNoConflict = window.define;
+        window.define = function () {
+            var factory = arguments[arguments.length - 1];
+            stealModule.exports = typeof factory === 'function' ? factory() : factory;
+        };
+        define.amd = true;
+        var _ = Object.create(null);
+        _.each = function () {
+        };
+        _.clone = function () {
+        };
+        if (typeof define == 'function' && typeof define.amd == 'object' && define.amd) {
+            define(function () {
+                return _;
+            });
+        } else if (freeModule) {
+            (freeModule.exports = _)._ = _;
+            freeExports._ = _;
+        }
+        window.define = __defineNoConflict;
+        window.__defineNoConflict = undefined;
+    }
+];


### PR DESCRIPTION
Closes #104 

The UMD-like detection is a little loose since it only checks there is a non-top-level `define()` and there is a reference to `define.amd`.... I felt like tightening the condition might cause issues with legit UMD modules doing weird stuff.

Thoughts @matthewp?