### PR TITLE
Revert placing exports before imports in slim output

### DIFF
--- a/lib/amd/slim_builder.js
+++ b/lib/amd/slim_builder.js
@@ -274,11 +274,6 @@ module.exports = {
 	 */
 	transformCjsRequiresAndExports: function(blockBody) {
 		var cloned = cloneDeep(blockBody);
-		var __exports = [];
-
-		function collectExport(node) {
-			__exports = __exports.concat(cloned.splice(cloned.indexOf(node), 1));
-		}
 
 		types.visit(cloned, {
 			// require(moduleId)
@@ -294,8 +289,6 @@ module.exports = {
 
 					if (includes(["exports", "module"], name)) {
 						node.arguments[0] = this.replacements[name];
-						// ExpressionStatement > CallExpression
-						collectExport(path.parent.node);
 					}
 				}
 
@@ -310,8 +303,6 @@ module.exports = {
 
 				if (includes(keys(this.replacements), memberObject.name)) {
 					node.object = this.replacements[memberObject.name];
-					// ExpressionStatement > AssignmentExpression > MemberExpression
-					collectExport(path.parent.parent.node);
 				}
 
 				this.traverse(path);
@@ -344,6 +335,6 @@ module.exports = {
 			}
 		});
 
-		return concat(__exports, cloned);
+		return cloned;
 	}
 };

--- a/test/tests/expected/amd_babel_slim.js
+++ b/test/tests/expected/amd_babel_slim.js
@@ -1,12 +1,12 @@
 [
     'amd_babel',
     function (stealRequire, stealExports, stealModule) {
+        var _jquery = stealRequire('jquery');
+        'use strict';
         Object.defineProperty(stealExports, '__esModule', { value: true });
         stealExports.default = function (selector) {
             (0, _jquery2.default)(selector).hide();
         };
-        var _jquery = stealRequire('jquery');
-        'use strict';
         var _jquery2 = _interopRequireDefault(_jquery);
         function _interopRequireDefault(obj) {
             return obj && obj.__esModule ? obj : { default: obj };

--- a/test/tests/expected/amd_cjs_module_slim.js
+++ b/test/tests/expected/amd_cjs_module_slim.js
@@ -1,11 +1,11 @@
 [
     'amd_cjs_module',
     function (stealRequire, stealExports, stealModule) {
+        var a = stealRequire('a'), b = stealRequire('b');
         stealModule.exports = {
             action: function () {
                 console.log('hello world');
             }
         };
-        var a = stealRequire('a'), b = stealRequire('b');
     }
 ];

--- a/test/tests/expected/amd_cjs_wrapper_slim.js
+++ b/test/tests/expected/amd_cjs_wrapper_slim.js
@@ -1,9 +1,9 @@
 [
     'amd_cjs_wrapper',
     function (stealRequire, stealExports, stealModule) {
+        var a = stealRequire('a'), b = stealRequire('b');
         stealExports.action = function () {
             console.log('hello world');
         };
-        var a = stealRequire('a'), b = stealRequire('b');
     }
 ];

--- a/test/tests/expected/amd_require_exports_slim.js
+++ b/test/tests/expected/amd_require_exports_slim.js
@@ -1,9 +1,9 @@
 [
     'amd_require_exports',
     function (stealRequire, stealExports, stealModule) {
+        var beta = stealRequire('beta');
         stealExports.verb = function () {
             return beta.verb();
         };
-        var beta = stealRequire('beta');
     }
 ];

--- a/test/tests/expected/cjs_amd_slim.js
+++ b/test/tests/expected/cjs_amd_slim.js
@@ -1,9 +1,9 @@
 [
     'cjs',
     function (stealRequire, stealExports, stealModule) {
+        var a = stealRequire('a'), b = stealRequire('b');
         stealExports.action = function () {
             console.log(`hello world`);
         };
-        var a = stealRequire('a'), b = stealRequire('b');
     }
 ];


### PR DESCRIPTION
Reverts #96
Closes #102 

We made this change to improve support for circular dependencies.

See http://2ality.com/2014/09/es6-modules-final.html#cyclic-dependencies-in-commonjs

but the implementation was very naive, braking modules using single value exports and local variables, and (from the linked article):

_CommonJS has one unique feature: you can export before importing. Such exports are guaranteed to be accessible in the bodies of importing modules. That is, if A did that, they could be accessed in B’s body. However, exporting before importing is rarely useful._

Circular dependencies are still supported, with the same caveats regular CJS modules have.