### PR TITLE
Pass require, exports, module into global/dirname wrapper function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+package-lock.json
 node_modules
 coverage
 demo/out*

--- a/lib/cjs_amd.js
+++ b/lib/cjs_amd.js
@@ -168,26 +168,22 @@ function defineWrapper(options) {
 	if (options.needsFunctionWrapper) {
 		wrapper += "(function(";
 		if (options.hasGlobal) {
-			wrapper += "global";
-		}
-		if (options.hasGlobal && options.hasDirname) {
-			wrapper += ", ";
+			wrapper += "global, ";
 		}
 		if (options.hasDirname) {
-			wrapper += "__dirname";
+			wrapper += "__dirname, ";
 		}
+		wrapper += "require, exports, module";
 		wrapper += "){\n";
 		wrapper += "})(";
 
 		if (options.hasGlobal) {
-			wrapper += "function() { return this; }()";
-		}
-		if (options.hasGlobal && options.hasDirname) {
-			wrapper += ", ";
+			wrapper += "function() { return this; }(), ";
 		}
 		if (options.hasDirname) {
-			wrapper += '"/"';
+			wrapper += '"/", ';
 		}
+		wrapper += "require, exports, module";
 		wrapper += ");";
 	}
 

--- a/test/tests/cjs_global.js
+++ b/test/tests/cjs_global.js
@@ -1,3 +1,5 @@
+var module;
 global.setTimeout(function(){
 
 });
+module.exports = {};

--- a/test/tests/expected/cjs_dirname.js
+++ b/test/tests/expected/cjs_dirname.js
@@ -1,5 +1,5 @@
 define(function (require, exports, module) {
-    (function (__dirname) {
+    (function (__dirname, require, exports, module) {
         var p = __dirname + '/foo';
-    }('/'));
+    }('/', require, exports, module));
 });

--- a/test/tests/expected/cjs_global.js
+++ b/test/tests/expected/cjs_global.js
@@ -1,8 +1,10 @@
 define(function (require, exports, module) {
-    (function (global) {
+    (function (global, require, exports, module) {
+        var module;
         global.setTimeout(function () {
         });
+        module.exports = {};
     }(function () {
         return this;
-    }()));
+    }(), require, exports, module));
 });

--- a/test/tests/expected/cjs_global_dirname.js
+++ b/test/tests/expected/cjs_global_dirname.js
@@ -1,8 +1,8 @@
 define(function (require, exports, module) {
-    (function (global, __dirname) {
+    (function (global, __dirname, require, exports, module) {
         var Math = global.Math;
         var p = __dirname + '/foo';
     }(function () {
         return this;
-    }(), '/'));
+    }(), '/', require, exports, module));
 });

--- a/test/tests/expected/cjs_global_without_dot.js
+++ b/test/tests/expected/cjs_global_without_dot.js
@@ -1,10 +1,10 @@
 define(function (require, exports, module) {
-    (function (global) {
+    (function (global, require, exports, module) {
         var foo = getFromGlobal(global, 'foo');
         function getFromGlobal(global, prop) {
             return global[prop];
         }
     }(function () {
         return this;
-    }()));
+    }(), require, exports, module));
 });


### PR DESCRIPTION
Passing these values into the wrapper ensures that they are not masked
by variable declarations within the body of the module.

Closes #124