### PR TITLE
Support eval: script style globals

### DIFF
--- a/lib/global_amd.js
+++ b/lib/global_amd.js
@@ -20,6 +20,8 @@ module.exports = function(load){
 		preparedExportName = true;
 	}
 
+	var execMeta = metadata.eval &&
+		('{' + "'eval': '" + metadata.eval + "'" + "}");
 	var source = jsStringEscape(load.source);
 	var code = "define(\"" + name + "\", " + JSON.stringify(deps) +
 		", function(module, loader, require) {\n" +
@@ -37,7 +39,9 @@ module.exports = function(load){
         "  loader.global.define = undefined;\n" +
         "  loader.global.module = undefined;\n" +
         "  loader.global.exports = undefined;\n" +
-        "  loader.__exec({'source': source, 'address': module.uri});\n" +
+        "  loader.__exec({'source': source, 'address': module.uri" +
+			(execMeta ? (",'metadata': " + execMeta) : "") +
+			"});\n" +
         "  loader.global.require = require;\n" +
         "  loader.global.define = define;\n" +
 		"\n  return loader.get(\"@@global-helpers\").retrieveGlobal(module.id, " +

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,22 @@ describe("global - amd", function() {
 			load: load,
 			converter: global2amd,
 			sourceFileName: "global",
-			expectedFileName: "global_amd_init",
+			expectedFileName: "global_amd_init"
+		});
+	});
+
+	it("works with 'eval': 'script'", function() {
+		var load = {
+			metadata: {
+				format: "global",
+				eval: "script"
+			}
+		};
+		return convert({
+			load: load,
+			converter: global2amd,
+			sourceFileName: "global",
+			expectedFileName: "global_amd_eval"
 		});
 	});
 });

--- a/test/tests/expected/global_amd_eval.js
+++ b/test/tests/expected/global_amd_eval.js
@@ -1,0 +1,25 @@
+define('global', [
+    'module',
+    '@loader',
+    'require'
+], function (module, loader, require) {
+    loader.get('@@global-helpers').prepareGlobal({
+        require: require,
+        name: module.id,
+        deps: []
+    });
+    var define = loader.global.define;
+    var require = loader.global.require;
+    var source = 'var GLOBAL = "I don\'t like \\"Quotes\\"";';
+    loader.global.define = undefined;
+    loader.global.module = undefined;
+    loader.global.exports = undefined;
+    loader.__exec({
+        'source': source,
+        'address': module.uri,
+        'metadata': { 'eval': 'script' }
+    });
+    loader.global.require = require;
+    loader.global.define = define;
+    return loader.get('@@global-helpers').retrieveGlobal(module.id, undefined);
+});


### PR DESCRIPTION
This is needed for globals that don't explicit set themselves with
something like `global.someValue = function(){}`...