### PR TITLE
Add module name to slim output as a comment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 node_modules
 coverage
 demo/out*
+.vscode/

--- a/lib/amd/slim.js
+++ b/lib/amd/slim.js
@@ -18,6 +18,7 @@ module.exports = function(load, options) {
 	if (hasNestedDefine(currentAst) && hasDefineAmdReference(currentAst)) {
 		slimAst = slimBuilder.makeAstFromNestedDefine(
 			load.uniqueId || load.name,
+			load.name,
 			currentAst.body
 		);
 	} else {

--- a/lib/amd/slim_builder.js
+++ b/lib/amd/slim_builder.js
@@ -19,9 +19,12 @@ function isCjsKeyword(word) {
 }
 
 module.exports = {
-	slimWrapperTemplate: estemplate.compile(
-		"[%= moduleId %, function(%= params %) { %= body % }]"
-	),
+	slimWrapperTemplate: function slimWrapperTemplate(name) {
+		return estemplate.compile(
+			`[%= moduleId % /*${name}*/, function(%= params %) { %= body % }]`,
+			{ attachComment: true }
+		);
+	},
 
 	slimFunctionParams: {
 		1: [b.identifier("stealRequire")],
@@ -71,6 +74,7 @@ module.exports = {
 
 	makeAst: function(defineArguments) {
 		var id = defineArguments.id;
+		var name = defineArguments.name;
 		var factory = defineArguments.factory;
 		var dependencies = defineArguments.dependencies;
 
@@ -81,7 +85,7 @@ module.exports = {
 		);
 		var params = this.makeFunctionParams(dependencies, factory);
 
-		return this.slimWrapperTemplate({
+		return this.slimWrapperTemplate(name)({
 			body: body,
 			params: params,
 			moduleId: b.literal(id)
@@ -95,6 +99,7 @@ module.exports = {
 	 */
 	makeAstFromCjsWrapper: function(defineArguments) {
 		var id = defineArguments.id;
+		var name = defineArguments.name;
 		var factory = defineArguments.factory;
 		var dependencies = defineArguments.dependencies;
 
@@ -105,7 +110,7 @@ module.exports = {
 			defineArguments.name
 		);
 
-		return this.slimWrapperTemplate({
+		return this.slimWrapperTemplate(name)({
 			params: params,
 			moduleId: b.literal(id),
 			body: this.transformCjsRequiresAndExports(body)
@@ -118,8 +123,8 @@ module.exports = {
 	 * @param {Object} programBody - The AST top level body array
 	 * @return {Object} The slim node AST
 	 */
-	makeAstFromNestedDefine: function(moduleId, programBody) {
-		return this.slimWrapperTemplate({
+	makeAstFromNestedDefine: function(moduleId, moduleName, programBody) {
+		return this.slimWrapperTemplate(moduleName)({
 			moduleId: b.literal(moduleId),
 			params: this.slimFunctionParams[3],
 			body: concat(

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -4,7 +4,7 @@ module.exports = generate;
 
 function generate(ast, options, sourceContent){
 	var sourceMaps = options && options.sourceMaps;
-	var opts = {};
+	var opts = { comment: true };
 	if(sourceMaps) {
 		var includeContent = !!options.sourceMapsContent;
 

--- a/main.js
+++ b/main.js
@@ -52,8 +52,8 @@ var transformsEs6ToAmd = partial(endsWith, "es6", "amd");
 // transpile.to
 var transpile = {
 	transpilers: transpilers,
-	to: function(load, destFormat, options) {
-		options = options || {};
+	to: function(load, destFormat, opts) {
+		var options = opts || {};
 		var sourceFormat = load.metadata.format || moduleType(load.source);
 		var path = this.able(sourceFormat, destFormat);
 

--- a/test/tests/expected/amd_babel_slim.js
+++ b/test/tests/expected/amd_babel_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_babel',
+    /*amd_babel*/
     function (stealRequire, stealExports, stealModule) {
         var _jquery = stealRequire('jquery');
         'use strict';

--- a/test/tests/expected/amd_cjs_module_slim.js
+++ b/test/tests/expected/amd_cjs_module_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_cjs_module',
+    /*amd_cjs_module*/
     function (stealRequire, stealExports, stealModule) {
         var a = stealRequire('a'), b = stealRequire('b');
         stealModule.exports = {

--- a/test/tests/expected/amd_cjs_wrapper_slim.js
+++ b/test/tests/expected/amd_cjs_wrapper_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_cjs_wrapper',
+    /*amd_cjs_wrapper*/
     function (stealRequire, stealExports, stealModule) {
         var a = stealRequire('a'), b = stealRequire('b');
         stealExports.action = function () {

--- a/test/tests/expected/amd_deps_slim.js
+++ b/test/tests/expected/amd_deps_slim.js
@@ -1,5 +1,6 @@
 [
     'amd',
+    /*amd*/
     function (stealRequire, stealExports, stealModule) {
         var es6 = stealRequire('basics/es6module');
         stealModule.exports = {

--- a/test/tests/expected/amd_dynamic_import_slim.js
+++ b/test/tests/expected/amd_dynamic_import_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_dynamic_import',
+    /*amd_dynamic_import*/
     function (stealRequire) {
         stealRequire.dynamic('foo').then(function (foo) {
             window.foo = foo;

--- a/test/tests/expected/amd_jquery_slim.js
+++ b/test/tests/expected/amd_jquery_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_jquery',
+    /*amd_jquery*/
     function (stealRequire, stealExports, stealModule) {
         window.__defineNoConflict = window.define;
         window.define = function (name, deps, factory) {

--- a/test/tests/expected/amd_module_identifier_slim.js
+++ b/test/tests/expected/amd_module_identifier_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_module_identifier',
+    /*amd_module_identifier*/
     function (stealRequire, stealExports, stealModule) {
         stealModule.id = 'amd_module_identifier';
         var doSomething = function id(x) {

--- a/test/tests/expected/amd_module_member_expression_slim.js
+++ b/test/tests/expected/amd_module_member_expression_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_module_member_expression',
+    /*amd_module_member_expression*/
     function (stealRequire, stealExports, stealModule) {
         stealModule.id = 'amd_module_member_expression';
         stealModule.exports = stealModule.id;

--- a/test/tests/expected/amd_named_deps_slim.js
+++ b/test/tests/expected/amd_named_deps_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_named_deps',
+    /*amd_named_deps*/
     function (stealRequire, stealExports, stealModule) {
         var bar = stealRequire('bar');
         stealModule.exports = bar;

--- a/test/tests/expected/amd_needing_normalize_slim.js
+++ b/test/tests/expected/amd_needing_normalize_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_needing_normalize',
+    /*amd_needing_normalize*/
     function (stealRequire, stealExports, stealModule) {
         var stache = stealRequire('can/view/stache/stache');
         stealRequire('./tabs.less');

--- a/test/tests/expected/amd_nodeps_slim.js
+++ b/test/tests/expected/amd_nodeps_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_anon_nodeps',
+    /*amd_anon_nodeps*/
     function (stealRequire, stealExports, stealModule) {
         stealModule.exports = 'foo';
     }

--- a/test/tests/expected/amd_object_slim.js
+++ b/test/tests/expected/amd_object_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_object',
+    /*amd_object*/
     function (stealRequire, stealExports, stealModule) {
         stealModule.exports = { foo: 'foo' };
     }

--- a/test/tests/expected/amd_require_exports_slim.js
+++ b/test/tests/expected/amd_require_exports_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_require_exports',
+    /*amd_require_exports*/
     function (stealRequire, stealExports, stealModule) {
         var beta = stealRequire('beta');
         stealExports.verb = function () {

--- a/test/tests/expected/amd_rollup_umd_slim.js
+++ b/test/tests/expected/amd_rollup_umd_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_rollup_umd',
+    /*amd_rollup_umd*/
     function (stealRequire, stealExports, stealModule) {
         window.__defineNoConflict = window.define;
         window.define = function (name, deps, factory) {

--- a/test/tests/expected/amd_umd_slim.js
+++ b/test/tests/expected/amd_umd_slim.js
@@ -1,5 +1,6 @@
 [
     'amd_umd',
+    /*amd_umd*/
     function (stealRequire, stealExports, stealModule) {
         window.__defineNoConflict = window.define;
         window.define = function (name, deps, factory) {

--- a/test/tests/expected/cjs_amd_slim.js
+++ b/test/tests/expected/cjs_amd_slim.js
@@ -1,5 +1,6 @@
 [
     'cjs',
+    /*cjs*/
     function (stealRequire, stealExports, stealModule) {
         var a = stealRequire('a'), b = stealRequire('b');
         stealExports.action = function () {


### PR DESCRIPTION
This helps debugging since it's almost impossible to identify the module source with the numeric ids written out by the slim build.

[steal-tools build](https://github.com/stealjs/steal-tools/pull/927)

![carbon](https://user-images.githubusercontent.com/724877/35125612-895e2a00-fc67-11e7-98c6-003d4047b0c9.png)

