### PR TITLE
Make es2015 the only required preset

### DIFF
--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -7,14 +7,20 @@ module.exports = function(source, compileOptions, options){
 	});
 
 	// presets are applied from last to first
-	var defaultPresets = [
-		"react",
-		"stage-0",
-		["es2015", {loose: false, modules: compileOptions.modules}]
-	];
+	var presets;
+	var required = ["es2015", {loose: false, modules: compileOptions.modules}];
 
-	// user defined presets will override the default ones.
-	opts.presets = defaultPresets.concat(opts.presets || []);
+	if(opts.presets && opts.presets.length) {
+		presets = [required].concat(opts.presets);
+	} else {
+		presets = [
+			"react",
+			"stage-0",
+			required
+		];
+	}
+
+	opts.presets = presets;
 	opts.plugins = opts.plugins || [];
 
 	// Remove Babel 5 options

--- a/test/test.js
+++ b/test/test.js
@@ -374,6 +374,21 @@ describe("es6 - amd", function() {
 		});
 	});
 
+	it("stage0 is not a required preset", function() {
+		return doTranspile({
+			moduleFormat: "es6",
+			resultModuleFormat: "amd",
+			sourceFileName: "es6_and_async",
+			expectedFileName: "es6_and_async",
+			options: {
+				transpiler: "babel",
+				babelOptions: {
+					presets: ["react"]
+				}
+			}
+		});
+	});
+
 	it("should work with babel plugins NOT included in babel-standalone", function() {
 		return doTranspile({
 			moduleFormat: "es6",

--- a/test/tests/es6_and_async.js
+++ b/test/tests/es6_and_async.js
@@ -1,0 +1,9 @@
+var dep = require("dep");
+
+class App {
+
+}
+
+async function run() {
+	new App();
+}

--- a/test/tests/expected/es6_and_async.js
+++ b/test/tests/expected/es6_and_async.js
@@ -1,0 +1,14 @@
+define(['dep'], function (dep) {
+    'use strict';
+    function _classCallCheck(instance, Constructor) {
+        if (!(instance instanceof Constructor)) {
+            throw new TypeError('Cannot call a class as a function');
+        }
+    }
+    var App = function App() {
+        _classCallCheck(this, App);
+    };
+    async function run() {
+        new App();
+    }
+});


### PR DESCRIPTION
Going with what steal does, es2015 should be the only *required* preset.

https://github.com/stealjs/steal/blob/d8d8259daafd38dfa408cb531889e37d7b8bb1f1/src/loader/lib/transpiler.js#L298