### PR TITLE
Refactor amd to amd transpiler

### DIFF
--- a/lib/amd_amd.js
+++ b/lib/amd_amd.js
@@ -1,58 +1,77 @@
 var getAst = require("./get_ast");
-var traverse = require('./traverse');
-var comparify = require('comparify');
-var optionsNormalize = require('./options_normalize');
+var types = require("ast-types");
+var optionsNormalize = require("./options_normalize");
+
+var b = types.builders;
+var n = types.namedTypes;
 
 /**
- *
  * @param {Object} load
  * @param {Object} options
  *
  *   @option {Boolean} [namedDefines=false] Inserts a named define.
  */
-module.exports = function(load, options){
+module.exports = function transpileAmdToAmd(load, options) {
 	var ast = getAst(load);
 	var transformOptions = options || {};
 
-	traverse(ast, function(obj){
-		if(	comparify(obj,{
-					"type": "CallExpression",
-					"callee": {
-						"type": "Identifier",
-						"name": "define"
-					}
-				})  ) {
-			var args = obj.arguments,
-				arg = args[0];
+	if (!load.name) {
+		return ast;
+	}
 
-			if( transformOptions.namedDefines && arg.type !== "Literal" ) {
-				args.unshift({
-					type: "Literal",
-					value: optionsNormalize(options, load.name, load.name, load.address)
-				});
-				args[0].raw = args[0].value;
-				arg = args[1];
-			} else if(transformOptions.namedDefines && arg.type === "Literal"  && load.name) {
-				// make sure the name is right
-				args[0].value = load.name;
-				args[0].raw = args[0].value;
-				arg = args[1];
+	types.visit(ast, {
+		visitCallExpression: function visitCallExpression(path) {
+			if (!this.isDefineExpression(path)) {
+				return this.visit(path);
 			}
 
-			// Perform normalization on the dependency names, if needed
-			if(arg.type === "ArrayExpression") {
-				var i = 0;
-				var element;
+			var node = path.node;
+			var defineArgs = node.arguments;
+			var insertModuleName = transformOptions.namedDefines;
 
-				while(i < arg.elements.length) {
-					element = arg.elements[i];
-					element.value = optionsNormalize(options, element.value, load.name, load.address);
-					element.raw = '"' + element.value + '"';
-					i++;
+			// make sure the module is named appropiately
+			if (insertModuleName) {
+				var isAnonymousModule = !n.Literal.check(defineArgs[0]);
+				var normalized = optionsNormalize(
+					options,
+					load.name,
+					load.name,
+					load.address
+				);
+				if (isAnonymousModule) {
+					defineArgs.unshift(b.literal(normalized));
+				} else {
+					defineArgs[0] = b.literal(normalized);
 				}
 			}
 
-			return false;
+			// define(name, dependencies?, factory?)
+			// normalize the module dependencies if any
+			var maybeDependencies = defineArgs[1];
+			if (n.ArrayExpression.check(maybeDependencies)) {
+				var normalizedArgs = maybeDependencies.elements.map(
+					function eachArg(arg) {
+						return b.literal(
+							optionsNormalize(
+								options,
+								arg.value,
+								load.name,
+								load.address
+							)
+						);
+					}
+				);
+				maybeDependencies.elements = normalizedArgs;
+			}
+
+			this.abort(path);
+		},
+
+		isDefineExpression: function isDefineExpression(path) {
+			return (
+				n.Identifier.check(path.node.callee) &&
+				path.node.callee.name === "define"
+			);
 		}
 	});
 


### PR DESCRIPTION
- Removes comparify usage
- `ast-types` is a lot nicer to traverse the graph
- Replaces nodes when mutations happen, replacing only the value breaks line/pos data (and potentially sourcemaps, ideally we should track the mutations, using recast would help)
