### PR TITLE
Add forceES5 option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 4
   - 6
   - 8
+  - node
 sudo: false

--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -5,9 +5,9 @@ function getBabelPlugins(userDefinedPlugins, options) {
 	var plugins = userDefinedPlugins || [];
 	var transformModulesPlugin = "transform-es2015-modules-amd";
 
-	// we must include the transform modules plugin when the ES2015 presets
+	// we must include the transform modules plugin when the ES2015 preset
 	// is not used due to options.forceES5 being false
-	if (!options.forceES5 && !plugins.includes(transformModulesPlugin)) {
+	if (options.forceES5 === false && !plugins.includes(transformModulesPlugin)) {
 		plugins.push(transformModulesPlugin);
 	}
 
@@ -20,11 +20,11 @@ function getBabelPresets(userDefinedPresets, modules, options) {
 
 	// presets are applied from last to first
 	if(userDefinedPresets && userDefinedPresets.length) {
-		presets = options.forceES5
+		presets = options.forceES5 !== false
 			? [es2015Preset].concat(userDefinedPresets)
 			: userDefinedPresets
 	} else {
-		presets = options.forceES5
+		presets = options.forceES5 !== false
 			? ["react", "stage-0", es2015Preset]
 			: ["react"]
 	}

--- a/lib/babel_compile.js
+++ b/lib/babel_compile.js
@@ -1,27 +1,44 @@
 var babel = require("babel-standalone");
 var assign = require("lodash/assign");
 
+function getBabelPlugins(userDefinedPlugins, options) {
+	var plugins = userDefinedPlugins || [];
+	var transformModulesPlugin = "transform-es2015-modules-amd";
+
+	// we must include the transform modules plugin when the ES2015 presets
+	// is not used due to options.forceES5 being false
+	if (!options.forceES5 && !plugins.includes(transformModulesPlugin)) {
+		plugins.push(transformModulesPlugin);
+	}
+
+	return plugins;
+}
+
+function getBabelPresets(userDefinedPresets, modules, options) {
+	var presets;
+	var es2015Preset = ["es2015", {loose: false, modules: modules}];
+
+	// presets are applied from last to first
+	if(userDefinedPresets && userDefinedPresets.length) {
+		presets = options.forceES5
+			? [es2015Preset].concat(userDefinedPresets)
+			: userDefinedPresets
+	} else {
+		presets = options.forceES5
+			? ["react", "stage-0", es2015Preset]
+			: ["react"]
+	}
+
+	return presets;
+}
+
 module.exports = function(source, compileOptions, options){
 	var opts = assign({}, options.babelOptions, {
 		sourceMap: compileOptions.sourceMaps || false
 	});
 
-	// presets are applied from last to first
-	var presets;
-	var required = ["es2015", {loose: false, modules: compileOptions.modules}];
-
-	if(opts.presets && opts.presets.length) {
-		presets = [required].concat(opts.presets);
-	} else {
-		presets = [
-			"react",
-			"stage-0",
-			required
-		];
-	}
-
-	opts.presets = presets;
-	opts.plugins = opts.plugins || [];
+	opts.presets = getBabelPresets(opts.presets, compileOptions.modules, options);
+	opts.plugins = getBabelPlugins(opts.plugins, options);
 
 	// Remove Babel 5 options
 	delete opts.optional;

--- a/main.js
+++ b/main.js
@@ -2,6 +2,7 @@ var bfs = require("./lib/bfs");
 var generate = require("./lib/generate");
 var getAst = require("./lib/get_ast");
 var partial = require("lodash/partial");
+var defaults = require("lodash/defaults");
 var detect = require("js-module-formats").detect;
 var sourceMapFileName = require("./lib/source_map_filename");
 var makeFormatsGraph = require("./lib/make_transforms_formats_graph.js");
@@ -52,7 +53,7 @@ var transformsCjsToAmd = partial(endsWith, "cjs", "amd");
 var transpile = {
 	transpilers: transpilers,
 	to: function(load, destFormat, opts) {
-		var options = opts || {};
+		var options = defaults(opts || {}, { forceES5: true });
 		var sourceFormat = load.metadata.format || moduleType(load.source);
 		var path = this.able(sourceFormat, destFormat);
 

--- a/test/convert.js
+++ b/test/convert.js
@@ -4,15 +4,16 @@ var path = require("path");
 var assert = require("assert");
 var assign = require("lodash/assign");
 var generate = require("../lib/generate");
+var defaults = require("lodash/defaults");
 
 var readFile = Q.denodeify(fs.readFile);
 var isWindows = /^win/.test(process.platform);
 
 module.exports = function convert(args) {
 	var converter = args.converter;
-	var options = args.options || {};
 	var sourceFileName = args.sourceFileName;
 	var expectedFileName = args.expectedFileName;
+	var options = defaults(args.options || {}, { forceES5: true });
 
 	var srcAddress = path.join(__dirname, "tests", sourceFileName + ".js");
 

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ describe("es6 - cjs", function() {
 
 		var e = "'use strict';\nvar GoogleMapReact = require('google-map-react');";
 		assert.equal(res.code, e);
-	})
+	});
 
 	it("works if global.System is something else (#14)", function() {
 		global.System = {};
@@ -446,6 +446,19 @@ describe("es6 - amd", function() {
 				traceurOptions: {
 					properTailCalls: true
 				}
+			}
+		});
+	});
+
+	it("can skip es2015 transforms with options.forceES5", function() {
+		return doTranspile({
+			moduleFormat: "es6",
+			resultModuleFormat: "amd",
+			sourceFileName: "es6_and_async",
+			expectedFileName: "es6_and_async_not_es5",
+			options: {
+				transpiler: "babel",
+				forceES5: false
 			}
 		});
 	});

--- a/test/tests/expected/es6_and_async_not_es5.js
+++ b/test/tests/expected/es6_and_async_not_es5.js
@@ -1,0 +1,8 @@
+define(['dep'], function (dep) {
+    'use strict';
+    class App {
+    }
+    async function run() {
+        new App();
+    }
+});


### PR DESCRIPTION
It defaults to `true` and when turned off, it removes the ES2015 preset from the Babel options (and adds the babel-plugin-transform-es2015-modules-amd plugin to make sure modules are transformed as expected), this change only affects any transform from the ES6 format through Babel.