### PR TITLE
Allow sourcemaps to be skipped in ES6->AMD transform

### DIFF
--- a/lib/es6_amd.js
+++ b/lib/es6_amd.js
@@ -10,7 +10,7 @@ module.exports = function(load, options) {
 		{
 			filename: options.sourceMapFileName || load.address,
 			modules: "amd",
-			sourceMaps: true
+			sourceMaps: options.sourceMaps !== false
 		},
 		options
 	);

--- a/test/test.js
+++ b/test/test.js
@@ -462,6 +462,22 @@ describe("es6 - amd", function() {
 			}
 		});
 	});
+
+	it("allows sourcemaps generation to be skipped", function() {
+		var es6ToAmd = require("../lib/es6_amd");
+
+		var load = {
+			source: "import foo from 'bar';",
+			name: "foo"
+		};
+
+		es6ToAmd(load, {
+			transpiler: "babel",
+			sourceMaps: false
+		});
+
+		assert.equal(load.map, null, "should not generate sourcemaps");
+	});
 });
 
 describe("normalize options", function() {


### PR DESCRIPTION
Closes #144